### PR TITLE
fix(core): event without key

### DIFF
--- a/src/core/block.rs
+++ b/src/core/block.rs
@@ -48,7 +48,11 @@ async fn get_transfer_events(
             block_events
                 .clone()
                 .into_iter()
-                .filter(|e| e.keys[0] == get_selector_from_name("Transfer").unwrap()) // Assuming Transfer is a valid selector.
+                .filter(|e| {
+                    e.keys.get(0).map_or(false, |key| {
+                        *key == get_selector_from_name("Transfer").unwrap()
+                    })
+                })
                 .collect(),
         ))
     } else {


### PR DESCRIPTION
It seems there are events without keys. As a result, this caused the indexer to panic.

[Log](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Fecs$252Fark-indexer-testnet/log-events/ecs$252Fark_indexer$252F305191f8cbe546e69775ce2bedbe8cdf)
```
thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 0', src/core/block.rs:51:29
```

Tx: https://testnet.starkscan.co/tx/0x033c6db4129a58f862f3a8a56930441d6475c87766794c228fb5233fd1852d20