### PR TITLE
feat(pontos): upgrade indexer version handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5280,6 +5280,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
+ "version-compare",
 ]
 
 [[package]]
@@ -7605,6 +7606,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-compare"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "version_check"

--- a/crates/pontos/Cargo.toml
+++ b/crates/pontos/Cargo.toml
@@ -14,6 +14,7 @@ num-bigint = { version = "0.4.3", default-features = false }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0.32"
+version-compare = "0.1"
 
 anyhow.workspace = true
 tokio.workspace = true

--- a/crates/pontos/src/lib.rs
+++ b/crates/pontos/src/lib.rs
@@ -230,7 +230,7 @@ impl<S: Storage, C: StarknetClient, E: EventHandler + Send + Sync> Pontos<S, C, 
                 break;
             }
 
-            if self
+            if !self
                 .block_manager
                 .check_candidate(current_u64, &self.config.indexer_version, do_force)
                 .await?

--- a/crates/pontos/src/lib.rs
+++ b/crates/pontos/src/lib.rs
@@ -232,7 +232,7 @@ impl<S: Storage, C: StarknetClient, E: EventHandler + Send + Sync> Pontos<S, C, 
 
             if self
                 .block_manager
-                .check_candidate(current_u64, &self.config.indexer_version, do_force)
+                .should_skip_indexing(current_u64, &self.config.indexer_version, do_force)
                 .await?
             {
                 current_u64 += 1;

--- a/crates/pontos/src/lib.rs
+++ b/crates/pontos/src/lib.rs
@@ -230,7 +230,7 @@ impl<S: Storage, C: StarknetClient, E: EventHandler + Send + Sync> Pontos<S, C, 
                 break;
             }
 
-            if !self
+            if self
                 .block_manager
                 .check_candidate(current_u64, &self.config.indexer_version, do_force)
                 .await?

--- a/crates/pontos/src/lib.rs
+++ b/crates/pontos/src/lib.rs
@@ -40,7 +40,7 @@ impl From<anyhow::Error> for IndexerError {
 }
 
 pub struct PontosConfig {
-    pub indexer_version: u64,
+    pub indexer_version: String,
     pub indexer_identifier: String,
 }
 
@@ -232,7 +232,7 @@ impl<S: Storage, C: StarknetClient, E: EventHandler + Send + Sync> Pontos<S, C, 
 
             if self
                 .block_manager
-                .check_candidate(current_u64, self.config.indexer_version, do_force)
+                .check_candidate(current_u64, &self.config.indexer_version, do_force)
                 .await?
             {
                 current_u64 += 1;
@@ -245,7 +245,7 @@ impl<S: Storage, C: StarknetClient, E: EventHandler + Send + Sync> Pontos<S, C, 
             self.block_manager
                 .set_block_info(
                     current_u64,
-                    self.config.indexer_version,
+                    &self.config.indexer_version,
                     &self.config.indexer_identifier,
                     BlockIndexingStatus::Processing,
                 )
@@ -275,7 +275,7 @@ impl<S: Storage, C: StarknetClient, E: EventHandler + Send + Sync> Pontos<S, C, 
             self.block_manager
                 .set_block_info(
                     current_u64,
-                    self.config.indexer_version,
+                    &self.config.indexer_version,
                     &self.config.indexer_identifier,
                     BlockIndexingStatus::Terminated,
                 )

--- a/crates/pontos/src/managers/block_manager.rs
+++ b/crates/pontos/src/managers/block_manager.rs
@@ -60,8 +60,8 @@ impl<S: Storage> BlockManager<S> {
                     _ => Ok(false),
                 }
             }
-            Err(StorageError::NotFound) => Ok(true),
-            Err(_) => Ok(false),
+            Err(StorageError::NotFound) => Ok(false),
+            Err(_) => Ok(true),
         }
     }
 

--- a/crates/pontos/src/managers/block_manager.rs
+++ b/crates/pontos/src/managers/block_manager.rs
@@ -33,7 +33,7 @@ impl<S: Storage> BlockManager<S> {
 
     /// Returns false if the given block number must be indexed.
     /// True otherwise.
-    pub async fn check_candidate(
+    pub async fn should_skip_indexing(
         &self,
         block_number: u64,
         indexer_version: &str,
@@ -145,7 +145,7 @@ mod tests {
     };
 
     #[tokio::test]
-    async fn test_check_candidate_not_found() {
+    async fn test_should_skip_indexing_not_found() {
         let mut mock_storage = MockStorage::default();
 
         // Mock the get_block_info to return NotFound.
@@ -167,7 +167,7 @@ mod tests {
 
         // Should return false as the block is not found.
         let result = manager
-            .check_candidate(block_number, "v0.0.2", false)
+            .should_skip_indexing(block_number, "v0.0.2", false)
             .await
             .unwrap();
 
@@ -175,7 +175,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_check_candidate() {
+    async fn test_should_skip_indexing() {
         let mut mock_storage = MockStorage::default();
 
         // Mock the clean_block method to return Ok(()).
@@ -208,11 +208,17 @@ mod tests {
         };
 
         // New version, should return true for indexing.
-        let result = manager.check_candidate(1, "v0.0.2", false).await.unwrap();
+        let result = manager
+            .should_skip_indexing(1, "v0.0.2", false)
+            .await
+            .unwrap();
         assert!(result == false);
 
         // Force but same version, should return true for indexing.
-        let result = manager.check_candidate(2, "v0.0.1", true).await.unwrap();
+        let result = manager
+            .should_skip_indexing(2, "v0.0.1", true)
+            .await
+            .unwrap();
         assert!(result == false);
     }
 }

--- a/crates/pontos/src/managers/block_manager.rs
+++ b/crates/pontos/src/managers/block_manager.rs
@@ -1,6 +1,6 @@
 use crate::storage::types::{BlockIndexingStatus, BlockInfo, StorageError};
 use crate::storage::Storage;
-use log::debug;
+use log::{debug, trace};
 use starknet::core::types::FieldElement;
 use std::sync::Arc;
 use version_compare::{compare, Cmp};
@@ -48,9 +48,9 @@ impl<S: Storage> BlockManager<S> {
 
         match self.storage.get_block_info(block_number).await {
             Ok(info) => {
-                debug!("Block {} already indexed", block_number);
+                trace!("Block {} already indexed", block_number);
 
-                println!(
+                debug!(
                     "Checking indexation version: current={:?}, last={:?}",
                     indexer_version, info.indexer_version
                 );

--- a/crates/pontos/src/managers/token_manager.rs
+++ b/crates/pontos/src/managers/token_manager.rs
@@ -3,7 +3,7 @@ use crate::storage::Storage;
 use anyhow::{anyhow, Result};
 use ark_starknet::client::StarknetClient;
 use ark_starknet::format::to_hex_str;
-use log::{debug, info};
+use log::warn;
 use starknet::core::types::*;
 use starknet::macros::selector;
 use std::sync::Arc;
@@ -84,11 +84,11 @@ impl<S: Storage, C: StarknetClient> TokenManager<S, C> {
                 .await
             {
                 Ok(res) => return Ok(res),
-                Err(_) => debug!("Failed to get token owner with {:?}", selector),
+                Err(_) => warn!("Failed to get token owner with {:?}", selector),
             }
         }
 
-        info!("Failed to get token owner");
+        warn!("Failed to get token owner");
         Err(anyhow!("Failed to get token owner from chain"))
     }
 }

--- a/crates/pontos/src/storage/types.rs
+++ b/crates/pontos/src/storage/types.rs
@@ -238,7 +238,7 @@ pub struct BlockIndexing {
 
 #[derive(Debug)]
 pub struct BlockInfo {
-    pub indexer_version: u64,
+    pub indexer_version: String,
     pub indexer_identifier: String,
     pub status: BlockIndexingStatus,
 }

--- a/examples/pontos.rs
+++ b/examples/pontos.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
 
     // Typically loaded from env.
     let config = PontosConfig {
-        indexer_version: 1,
+        indexer_version: String::from("0.0.1"),
         indexer_identifier: "task_1234".to_string(),
     };
 
@@ -163,8 +163,8 @@ impl Storage for DefaultStorage {
     async fn get_block_info(&self, block_number: u64) -> Result<BlockInfo, StorageError> {
         log::trace!("Getting block info for block #{}", block_number);
         Ok(BlockInfo {
-            indexer_version: 0,
-            indexer_identifier: "v0".to_string(),
+            indexer_version: String::from("0.0.1"),
+            indexer_identifier: String::from("v0"),
             status: BlockIndexingStatus::None,
         })
     }

--- a/examples/pontos_pending.rs
+++ b/examples/pontos_pending.rs
@@ -22,8 +22,8 @@ async fn main() -> Result<()> {
 
     // Typically loaded from env.
     let config = PontosConfig {
-        indexer_version: 1,
-        indexer_identifier: "task_1234".to_string(),
+        indexer_version: String::from("0.0.1"),
+        indexer_identifier: "TASK#123".to_string(),
     };
 
     let pontos = Arc::new(Pontos::new(
@@ -135,8 +135,8 @@ impl Storage for DefaultStorage {
     async fn get_block_info(&self, block_number: u64) -> Result<BlockInfo, StorageError> {
         log::trace!("Getting block info for block #{}", block_number);
         Ok(BlockInfo {
-            indexer_version: 0,
-            indexer_identifier: "v0".to_string(),
+            indexer_version: String::from("0.0.1"),
+            indexer_identifier: String::from("v0"),
             status: BlockIndexingStatus::None,
         })
     }


### PR DESCRIPTION
This pull request introduces significant changes to our application's indexer version management. Here's a summary of the key changes made:

1. **Conversion of Indexer Version from `u64` to `String`**:
   - We have modified the data type of the indexer version from `u64` to `String`, allowing for more flexible version representation.

2. **Integration of Version Comparison Dependency**:
   - We have incorporated the `version-compare` dependency to facilitate version comparison operations within the `should_skip_indexing` (previously `check_candidate`) method.

These changes enhance the versatility and accuracy of our indexer version management, providing better compatibility with various version formats and enabling more robust version comparison. This improvement enhances the overall reliability and functionality of our application's indexing process.