### PR TITLE
fix(types): Update Storage Types for Token & Event

### DIFF
--- a/crates/pontos/src/storage/types.rs
+++ b/crates/pontos/src/storage/types.rs
@@ -42,10 +42,10 @@ pub enum EventType {
 impl fmt::Display for EventType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            EventType::Mint => write!(f, "🟢 Mint"),
-            EventType::Burn => write!(f, "🔴 Burn"),
-            EventType::Transfer => write!(f, "🔵 Transfer"),
-            EventType::Uninitialized => write!(f, "❓ Uninitialized"),
+            EventType::Mint => write!(f, "MINT"),
+            EventType::Burn => write!(f, "BURN"),
+            EventType::Transfer => write!(f, "TRANSFER"),
+            EventType::Uninitialized => write!(f, "UNINITIALIZED"),
         }
     }
 }
@@ -254,9 +254,9 @@ pub enum ContractType {
 impl ToString for ContractType {
     fn to_string(&self) -> String {
         match self {
-            ContractType::Other => "other".to_string(),
-            ContractType::ERC721 => "erc721".to_string(),
-            ContractType::ERC1155 => "erc1155".to_string(),
+            ContractType::Other => "OTHER".to_string(),
+            ContractType::ERC721 => "ERC721".to_string(),
+            ContractType::ERC1155 => "ERC1155".to_string(),
         }
     }
 }
@@ -266,8 +266,8 @@ impl FromStr for ContractType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "erc721" => Ok(ContractType::ERC721),
-            "erc1155" => Ok(ContractType::ERC1155),
+            "ERC721" => Ok(ContractType::ERC721),
+            "ERC1155" => Ok(ContractType::ERC1155),
             _ => Ok(ContractType::Other),
         }
     }


### PR DESCRIPTION
### :bug: fix(types): Update Storage Types for Token & Event

This PR addresses changes in the string representation of `EventType` and `ContractType` enums.

#### Changes:

1. **EventType Display Changes**:
   - `Mint`: Changed from "🟢 Mint" to "MINT"
   - `Burn`: Changed from "🔴 Burn" to "BURN"
   - `Transfer`: Changed from "🔵 Transfer" to "TRANSFER"
   - `Uninitialized`: Changed from "❓ Uninitialized" to "UNINITIALIZED"

2. **ContractType ToString Changes**:
   - `Other`: Changed from "other" to "OTHER"
   - `ERC721`: Remains "ERC721"
   - `ERC1155`: Remains "ERC1155"

3. **ContractType FromStr Changes**:
   - Updated to recognize "ERC721" and "ERC1155" in uppercase.
