### PR TITLE
refactor(pontos)!: refacto exposed types to be starknet independant

### DIFF
--- a/crates/pontos/src/managers/contract_manager.rs
+++ b/crates/pontos/src/managers/contract_manager.rs
@@ -11,14 +11,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{info, trace};
 
-pub struct CollectionManager<S: Storage, C: StarknetClient> {
+pub struct ContractManager<S: Storage, C: StarknetClient> {
     storage: Arc<S>,
     client: Arc<C>,
     /// A cache with contract address mapped to its type.
     cache: HashMap<FieldElement, ContractType>,
 }
 
-impl<S: Storage, C: StarknetClient> CollectionManager<S, C> {
+impl<S: Storage, C: StarknetClient> ContractManager<S, C> {
     /// Initializes a new instance.
     pub fn new(storage: Arc<S>, client: Arc<C>) -> Self {
         Self {

--- a/crates/pontos/src/managers/mod.rs
+++ b/crates/pontos/src/managers/mod.rs
@@ -1,5 +1,5 @@
-pub mod collection_manager;
-pub use collection_manager::CollectionManager;
+pub mod contract_manager;
+pub use contract_manager::ContractManager;
 
 pub mod event_manager;
 pub use event_manager::EventManager;

--- a/crates/pontos/src/managers/token_manager.rs
+++ b/crates/pontos/src/managers/token_manager.rs
@@ -31,7 +31,7 @@ impl<S: Storage, C: StarknetClient> TokenManager<S, C> {
         event: &TokenEvent,
     ) -> Result<()> {
         let mut token = TokenInfo {
-            address: event.contract_address.clone(),
+            contract_address: event.contract_address.clone(),
             token_id: event.token_id.clone(),
             token_id_hex: event.token_id_hex.clone(),
             ..Default::default()

--- a/crates/pontos/src/storage/mod.rs
+++ b/crates/pontos/src/storage/mod.rs
@@ -1,9 +1,10 @@
 pub mod types;
 pub mod utils;
 
-use crate::storage::types::{BlockInfo, ContractType, StorageError, TokenEvent, TokenInfo};
+use crate::storage::types::{
+    BlockInfo, ContractInfo, ContractType, StorageError, TokenEvent, TokenInfo,
+};
 use async_trait::async_trait;
-use starknet::core::types::FieldElement;
 
 #[cfg(test)]
 use mockall::automock;
@@ -26,17 +27,10 @@ pub trait Storage {
         block_number: u64,
     ) -> Result<(), StorageError>;
 
-    async fn get_contract_type(
-        &self,
-        contract_address: &FieldElement,
-    ) -> Result<ContractType, StorageError>;
+    async fn get_contract_type(&self, contract_address: &str)
+        -> Result<ContractType, StorageError>;
 
-    async fn register_contract_info(
-        &self,
-        contract_address: &FieldElement,
-        contract_type: &ContractType,
-        block_number: u64,
-    ) -> Result<(), StorageError>;
+    async fn register_contract_info(&self, info: &ContractInfo) -> Result<(), StorageError>;
 
     async fn set_block_info(&self, block_number: u64, info: BlockInfo) -> Result<(), StorageError>;
 

--- a/crates/pontos/src/storage/types.rs
+++ b/crates/pontos/src/storage/types.rs
@@ -98,7 +98,7 @@ impl Default for TokenEvent {
 // Token struct based on the informations we get from an event
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct TokenInfo {
-    pub address: String,
+    pub contract_address: String,
     pub token_id: String,
     pub token_id_hex: String,
     pub owner: String,

--- a/examples/pontos.rs
+++ b/examples/pontos.rs
@@ -8,7 +8,7 @@ use arkproject::pontos::{
     event_handler::EventHandler, storage::types::*, storage::Storage, Pontos, PontosConfig,
 };
 use async_trait::async_trait;
-use starknet::core::types::{BlockId, FieldElement};
+use starknet::core::types::BlockId;
 use std::sync::Arc;
 
 #[tokio::main]
@@ -135,22 +135,17 @@ impl Storage for DefaultStorage {
 
     async fn get_contract_type(
         &self,
-        contract_address: &FieldElement,
+        contract_address: &str,
     ) -> Result<ContractType, StorageError> {
         log::trace!("Getting contract info for contract {}", contract_address);
         Ok(ContractType::Other)
     }
 
-    async fn register_contract_info(
-        &self,
-        contract_address: &FieldElement,
-        contract_type: &ContractType,
-        _block_number: u64,
-    ) -> Result<(), StorageError> {
+    async fn register_contract_info(&self, info: &ContractInfo) -> Result<(), StorageError> {
         log::trace!(
-            "Registering contract info {:?} for contract {}",
-            contract_type,
-            contract_address
+            "Registering contract info {} for contract {}",
+            info.contract_type,
+            info.contract_address
         );
         Ok(())
     }

--- a/examples/pontos_pending.rs
+++ b/examples/pontos_pending.rs
@@ -8,7 +8,6 @@ use arkproject::pontos::{
     event_handler::EventHandler, storage::types::*, storage::Storage, Pontos, PontosConfig,
 };
 use async_trait::async_trait;
-use starknet::core::types::*;
 use std::sync::Arc;
 
 #[tokio::main]
@@ -104,25 +103,17 @@ impl Storage for DefaultStorage {
 
     async fn get_contract_type(
         &self,
-        contract_address: &FieldElement,
+        contract_address: &str,
     ) -> Result<ContractType, StorageError> {
-        log::trace!(
-            "Getting contract info for contract {:#64x}",
-            contract_address
-        );
+        log::trace!("Getting contract info for contract {}", contract_address);
         Ok(ContractType::Other)
     }
 
-    async fn register_contract_info(
-        &self,
-        contract_address: &FieldElement,
-        contract_type: &ContractType,
-        _block_number: u64,
-    ) -> Result<(), StorageError> {
+    async fn register_contract_info(&self, info: &ContractInfo) -> Result<(), StorageError> {
         log::trace!(
-            "Registering contract info {:?} for contract {:#64x}",
-            contract_type,
-            contract_address
+            "Registering contract info {} for contract {}",
+            info.contract_type,
+            info.contract_address
         );
         Ok(())
     }


### PR DESCRIPTION
## Description

BREAKING CHANGES: types and function signature were changed.

Ensure that storage exposed types are starknet agnostic, for a better
storage implementation in clients.

Also rename `collection` into `contract` for consistency across the project.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature (`feat:`)
- [ ] 🐛 Bug Fix (`fix:`)
- [ ] 📝 Documentation Update (`docs:`)
- [ ] 🎨 Style (`style:`)
- [ ] 🧑‍💻 Code Refactor (`refactor:`)
- [ ] 🔥 Performance Improvements (`perf:`)
- [ ] ✅ Test (`test:`)
- [ ] 🤖 Build (`build:`)
- [ ] 🔁 CI (`ci:`)
- [ ] 📦 Chore (`chore:`)
- [ ] ⏩ Revert (`revert:`)
- [X] 🚀 Breaking Changes (`BREAKING CHANGE:`)

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

