### PR TITLE
fix(pontos): filter and process only transfer-related events

### DIFF
--- a/crates/ark-starknet/src/client/http.rs
+++ b/crates/ark-starknet/src/client/http.rs
@@ -90,7 +90,7 @@ impl StarknetClient for StarknetClientHttp {
         let mut emitted_events = vec![];
         for e in events {
             if keys.is_some()
-                && e.keys.len() > 0
+                && !e.keys.is_empty()
                 && keys.as_ref().map_or(false, |keys| keys.contains(&e.keys))
             {
                 emitted_events.push(EmittedEvent {

--- a/crates/ark-starknet/src/client/http.rs
+++ b/crates/ark-starknet/src/client/http.rs
@@ -36,6 +36,7 @@ impl StarknetClient for StarknetClientHttp {
     async fn events_from_tx_receipt(
         &self,
         transaction_hash: FieldElement,
+        keys: Option<Vec<Vec<FieldElement>>>,
     ) -> Result<Vec<EmittedEvent>> {
         let receipt = self
             .provider
@@ -88,14 +89,19 @@ impl StarknetClient for StarknetClientHttp {
 
         let mut emitted_events = vec![];
         for e in events {
-            emitted_events.push(EmittedEvent {
-                from_address: e.from_address,
-                keys: e.keys,
-                data: e.data,
-                block_hash,
-                block_number,
-                transaction_hash,
-            })
+            if keys.is_some()
+                && e.keys.len() > 0
+                && keys.as_ref().map_or(false, |keys| keys.contains(&e.keys))
+            {
+                emitted_events.push(EmittedEvent {
+                    from_address: e.from_address,
+                    keys: e.keys,
+                    data: e.data,
+                    block_hash,
+                    block_number,
+                    transaction_hash,
+                })
+            }
         }
 
         Ok(emitted_events)

--- a/crates/ark-starknet/src/client/mod.rs
+++ b/crates/ark-starknet/src/client/mod.rs
@@ -23,6 +23,7 @@ pub trait StarknetClient {
     async fn events_from_tx_receipt(
         &self,
         transaction_hash: FieldElement,
+        keys: Option<Vec<Vec<FieldElement>>>,
     ) -> Result<Vec<EmittedEvent>>;
 
     ///

--- a/crates/pontos/src/lib.rs
+++ b/crates/pontos/src/lib.rs
@@ -137,7 +137,11 @@ impl<S: Storage, C: StarknetClient, E: EventHandler + Send + Sync> Pontos<S, C, 
                     if cache.is_tx_processed(&tx_hash) {
                         continue;
                     } else {
-                        match self.client.events_from_tx_receipt(tx_hash).await {
+                        match self
+                            .client
+                            .events_from_tx_receipt(tx_hash, self.event_manager.keys_selector())
+                            .await
+                        {
                             Ok(events) => {
                                 self.process_events(events, block_number, latest_ts).await?;
                                 cache.add_tx_as_processed(&tx_hash);
@@ -175,7 +179,11 @@ impl<S: Storage, C: StarknetClient, E: EventHandler + Send + Sync> Pontos<S, C, 
                     continue;
                 } else {
                     debug!("processing tx {:#064x}", tx_hash);
-                    match self.client.events_from_tx_receipt(tx_hash).await {
+                    match self
+                        .client
+                        .events_from_tx_receipt(tx_hash, self.event_manager.keys_selector())
+                        .await
+                    {
                         Ok(events) => {
                             self.process_events(events, block_number, cache.get_timestamp())
                                 .await?;

--- a/crates/pontos/src/managers/event_manager.rs
+++ b/crates/pontos/src/managers/event_manager.rs
@@ -39,7 +39,10 @@ impl<S: Storage> EventManager<S> {
     ) -> Result<TokenEvent> {
         let mut token_event = TokenEvent::default();
 
-        debug!("Processing event: {:?}", event);
+        debug!(
+            "Processing event: event={:?}, contract_type={:?}, timestamp={}",
+            event, contract_type, timestamp
+        );
 
         // As cairo didn't have keys before, we first check if the data
         // contains the info. If not, we check into the keys, skipping the first


### PR DESCRIPTION
## Description

It fixes the indexing error that occurs with the pending blocks:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ParseIntError { kind: PosOverflow }', 
``` 

## What type of PR is this? (check all applicable)
- [X] 🐛 Bug Fix (`fix:`)

## Added tests?
- [X] 🙋 no, because I need help

## Added to documentation?
- [X] 🙅 no documentation needed

![done](https://media2.giphy.com/media/R12GjfNoeaGNjTeget/giphy.gif)

## Closing Issues

- Fixes #135 will close issue 135 when the PR is merged.
