### PR TITLE
fix(pontos): indexer error message is now displayed correctly

### DIFF
--- a/crates/ark-starknet/src/format.rs
+++ b/crates/ark-starknet/src/format.rs
@@ -27,10 +27,7 @@ mod tests {
 
     #[test]
     fn test_to_hex_str_short() {
-        let address = FieldElement::from_hex_be(
-            "0x1234",
-        )
-        .unwrap();
+        let address = FieldElement::from_hex_be("0x1234").unwrap();
         let value = to_hex_str(&address);
         assert_eq!(
             value,

--- a/crates/ark-starknet/src/format.rs
+++ b/crates/ark-starknet/src/format.rs
@@ -3,7 +3,7 @@ use std::fmt::LowerHex;
 /// Returns the padded hex of '0x' prefixed
 /// representation of the given felt.
 pub fn to_hex_str<T: LowerHex>(value: &T) -> String {
-    format!("{:#064x}", value)
+    format!("0x{:064x}", value)
 }
 
 #[cfg(test)]
@@ -22,6 +22,19 @@ mod tests {
         assert_eq!(
             value,
             "0x07fec6349248dc1a35f3f9fafd19e1ef873b687e04b7b9db4806f9e54f9ef000"
+        );
+    }
+
+    #[test]
+    fn test_to_hex_str_short() {
+        let address = FieldElement::from_hex_be(
+            "0x1234",
+        )
+        .unwrap();
+        let value = to_hex_str(&address);
+        assert_eq!(
+            value,
+            "0x0000000000000000000000000000000000000000000000000000000000001234"
         );
     }
 }

--- a/crates/pontos/src/lib.rs
+++ b/crates/pontos/src/lib.rs
@@ -153,7 +153,7 @@ impl<S: Storage, C: StarknetClient, E: EventHandler + Send + Sync> Pontos<S, C, 
                                 cache.add_tx_as_processed(&tx_hash);
                             }
                             Err(e) => {
-                                error!("[latest] error processing tx {:#064x} {:?}", tx_hash, e);
+                                error!("[latest] error processing tx {:#066x} {:?}", tx_hash, e);
                                 // TODO: cleanup then?
                                 // This should not happen on the latest block, we want
                                 // to stop if this happen.
@@ -184,7 +184,7 @@ impl<S: Storage, C: StarknetClient, E: EventHandler + Send + Sync> Pontos<S, C, 
                 if cache.is_tx_processed(&tx_hash) {
                     continue;
                 } else {
-                    debug!("processing tx {:#064x}", tx_hash);
+                    debug!("processing tx {:#066x}", tx_hash);
                     match self.client.events_from_tx_receipt(tx_hash).await {
                         Ok(events) => {
                             self.process_events(events, block_number, cache.get_timestamp())
@@ -192,7 +192,7 @@ impl<S: Storage, C: StarknetClient, E: EventHandler + Send + Sync> Pontos<S, C, 
                             cache.add_tx_as_processed(&tx_hash);
                         }
                         Err(e) => {
-                            warn!("error processing tx {:#064x} {:?}", tx_hash, e);
+                            warn!("error processing tx {:#066x} {:?}", tx_hash, e);
                             // Sometimes, the tx hash is not found. To avoid
                             // loosing this tx as it will be available few seconds
                             // later, we skip it and try to parse it at the next

--- a/crates/pontos/src/lib.rs
+++ b/crates/pontos/src/lib.rs
@@ -8,6 +8,7 @@ use ark_starknet::client::StarknetClient;
 use event_handler::EventHandler;
 use managers::{BlockManager, ContractManager, EventManager, PendingBlockData, TokenManager};
 use starknet::core::types::*;
+use std::fmt;
 use std::sync::Arc;
 use storage::types::{ContractType, StorageError};
 use storage::Storage;
@@ -17,11 +18,9 @@ use tracing::{debug, error, info, trace, warn};
 pub type IndexerResult<T> = Result<T, IndexerError>;
 
 /// Generic errors for Pontos.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone)]
 pub enum IndexerError {
-    #[error("Storage error occurred")]
     StorageError(StorageError),
-    #[error("An error occurred")]
     Anyhow(String),
 }
 
@@ -36,6 +35,17 @@ impl From<anyhow::Error> for IndexerError {
         IndexerError::Anyhow(e.to_string())
     }
 }
+
+impl fmt::Display for IndexerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            IndexerError::StorageError(e) => write!(f, "Storage Error occurred: {}", e),
+            IndexerError::Anyhow(s) => write!(f, "An error occurred: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for IndexerError {}
 
 pub struct PontosConfig {
     pub indexer_version: String,

--- a/crates/pontos/src/managers/contract_manager.rs
+++ b/crates/pontos/src/managers/contract_manager.rs
@@ -62,7 +62,7 @@ impl<S: Storage, C: StarknetClient> ContractManager<S, C> {
                 let contract_type = self.get_contract_type(address).await?;
 
                 info!(
-                    "New contract identified [{:#064x}] : {}",
+                    "New contract identified [0x{:064x}] : {}",
                     address,
                     contract_type.to_string()
                 );

--- a/crates/pontos/src/storage/types.rs
+++ b/crates/pontos/src/storage/types.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum StorageError {
     DatabaseError,
     NotFound,


### PR DESCRIPTION
## Description

Errors was not displayed correctly, only a `En error occurred`.
Now the `IndexerError` are displayed correctly.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature (`feat:`)
- [x] 🐛 Bug Fix (`fix:`)
- [ ] 📝 Documentation Update (`docs:`)
- [ ] 🎨 Style (`style:`)
- [ ] 🧑‍💻 Code Refactor (`refactor:`)
- [ ] 🔥 Performance Improvements (`perf:`)
- [ ] ✅ Test (`test:`)
- [ ] 🤖 Build (`build:`)
- [ ] 🔁 CI (`ci:`)
- [ ] 📦 Chore (`chore:`)
- [ ] ⏩ Revert (`revert:`)
- [ ] 🚀 Breaking Changes (`BREAKING CHANGE:`)


## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 Documentation
- [X] 🙅 no documentation needed

