### PR TITLE
feat(pontos): add requested indexer status

### DIFF
--- a/crates/pontos/src/storage/types.rs
+++ b/crates/pontos/src/storage/types.rs
@@ -141,6 +141,7 @@ impl FromStr for BlockIndexingStatus {
 
 #[derive(Debug)]
 pub enum IndexerStatus {
+    Requested,
     Running,
     Stopped,
 }
@@ -148,6 +149,7 @@ pub enum IndexerStatus {
 impl fmt::Display for IndexerStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            IndexerStatus::Requested => write!(f, "requested"),
             IndexerStatus::Running => write!(f, "running"),
             IndexerStatus::Stopped => write!(f, "stopped"),
         }


### PR DESCRIPTION
Include the 'requested' status in the Indexer Status enumeration, which is currently missing.