### PR TITLE
feat(ark-starknet): add `from_hex_be` fn to `CairoU256`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ dependencies = [
  "async-trait",
  "mockall",
  "num-bigint",
+ "num-traits 0.2.16",
  "regex",
  "starknet",
  "url",

--- a/crates/ark-starknet/Cargo.toml
+++ b/crates/ark-starknet/Cargo.toml
@@ -11,6 +11,7 @@ url = "2.3.1"
 regex = "1.9.1"
 mockall = "0.11.2"
 num-bigint = { version = "0.4.3", default-features = false }
+num-traits = "0.2"
 
 [features]
 mock = []

--- a/crates/ark-starknet/src/lib.rs
+++ b/crates/ark-starknet/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod client;
 pub mod format;
 
+use anyhow::Result;
 use format::to_hex_str;
 use num_bigint::BigUint;
 
@@ -36,5 +37,91 @@ impl CairoU256 {
         } else {
             token_id_str
         }
+    }
+
+    pub fn from_hex_be(value: &str) -> Result<Self> {
+        // Remove the "0x" prefix if it exists
+        let value = value.trim_start_matches("0x");
+
+        // Parse the hexadecimal string into a BigUint
+        let big_uint_from_hex = match BigUint::parse_bytes(value.as_bytes(), 16) {
+            Some(big_uint) => big_uint,
+            None => return Err(anyhow::anyhow!("Invalid hexadecimal string")),
+        };
+
+        // Convert the BigUint to a 32-byte buffer
+        let mut buffer = [0u8; 32];
+        let hex_bytes = big_uint_from_hex.to_bytes_be();
+        let start = 32 - hex_bytes.len();
+        buffer[start..].copy_from_slice(&hex_bytes);
+
+        // Extract u128 values from the buffer
+        let low = u128::from_be_bytes(buffer[16..].try_into()?);
+        let high = u128::from_be_bytes(buffer[..16].try_into()?);
+
+        Ok(Self { low, high })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use num_traits::Num;
+
+    use super::*;
+
+    #[test]
+    fn test_to_biguint() {
+        let u256 = CairoU256 { low: 15, high: 0 };
+
+        let result = u256.to_biguint();
+        assert_eq!(result, BigUint::from_str_radix("15", 10).unwrap());
+    }
+
+    #[test]
+    fn test_to_hex() {
+        let u256 = CairoU256 { low: 15, high: 0 };
+
+        let expected_hex = "0x000000000000000000000000000000000000000000000000000000000000000f";
+        let result = u256.to_hex();
+        assert_eq!(result, expected_hex);
+    }
+
+    #[test]
+    fn test_to_decimal() {
+        let u256 = CairoU256 { low: 15, high: 0 };
+
+        let expected_decimal = "15";
+        let result = u256.to_decimal(false);
+        assert_eq!(result, expected_decimal);
+
+        let expected_padded_decimal =
+            "000000000000000000000000000000000000000000000000000000000000000000000000000015";
+        let result_padded = u256.to_decimal(true);
+        assert_eq!(result_padded, expected_padded_decimal);
+    }
+
+    #[test]
+    fn test_from_hex_be() {
+        let hex_string = "0x000000000000000000000000000000000000000000000000000000000000000f";
+        let u256 = CairoU256::from_hex_be(hex_string).unwrap();
+
+        assert_eq!(u256.low, 15);
+        assert_eq!(u256.high, 0);
+
+        // Test with invalid hex string
+        let invalid_hex_string = "invalidhex";
+        assert!(CairoU256::from_hex_be(invalid_hex_string).is_err());
+
+        let hex_string = "0x05f7cd1fd465baff2ba9d2d1501ad0a2eb5337d9a885be319366b5205a414fdd";
+        let u256 = CairoU256::from_hex_be(hex_string).unwrap();
+
+        assert_eq!(
+            u256.low,
+            u128::from_str_radix("0xeb5337d9a885be319366b5205a414fdd", 16).unwrap()
+        );
+        assert_eq!(
+            u256.high,
+            u128::from_str_radix("0x05f7cd1fd465baff2ba9d2d1501ad0a2", 16).unwrap()
+        );
     }
 }

--- a/crates/ark-starknet/src/lib.rs
+++ b/crates/ark-starknet/src/lib.rs
@@ -58,9 +58,6 @@ impl CairoU256 {
         // Split the input array into two parts
         let (high, low) = bytes.split_at(16);
 
-        println!("BUF {:?}", high);
-        println!("BUF {:?}", low);
-
         let low = u128::from_be_bytes(low.try_into()?);
         let high = u128::from_be_bytes(high.try_into()?);
 


### PR DESCRIPTION
## Description

Add the from_hex_be function to the CairoU256 struct to enable creating a CairoU256 from a hexadecimal value.

## What type of PR is this? (check all applicable)

- [X] 🍕 Feature (`feat:`)

## Added tests?

- [X] 👍 yes

## Added to documentation?

- [X] 🙅 no documentation needed