### PR TITLE
fix(ark-metadata): add missing `find_token_ids_without_metadata` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "ark-metadata"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "ark-starknet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "ark-metadata"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "ark-starknet",
@@ -312,7 +312,7 @@ dependencies = [
  "async-trait",
  "mockall",
  "num-bigint",
- "num-traits 0.2.16",
+ "num-traits 0.2.17",
  "regex",
  "starknet",
  "url",

--- a/crates/ark-metadata/Cargo.toml
+++ b/crates/ark-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-metadata"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/ark-metadata/Cargo.toml
+++ b/crates/ark-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-metadata"
-version = "0.1.1"
+version = "0.1.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/ark-metadata/src/metadata_manager.rs
+++ b/crates/ark-metadata/src/metadata_manager.rs
@@ -389,6 +389,7 @@ mod tests {
                 contract_address,
                 ImageCacheOption::DoNotSave,
                 ipfs_gateway_uri,
+                Duration::from_secs(5),
             )
             .await;
 

--- a/crates/ark-metadata/src/metadata_manager.rs
+++ b/crates/ark-metadata/src/metadata_manager.rs
@@ -2,14 +2,15 @@ use crate::{
     cairo_string_parser::parse_cairo_long_string,
     file_manager::{FileInfo, FileManager},
     storage::Storage,
-    utils::{extract_metadata_from_headers, get_token_metadata},
+    utils::{extract_metadata_from_headers, file_extension_from_mime_type, get_token_metadata},
 };
 use anyhow::{anyhow, Result};
 use ark_starknet::{client::StarknetClient, format::to_hex_str, CairoU256};
 use reqwest::Client as ReqwestClient;
 use starknet::core::types::{BlockId, BlockTag, FieldElement};
 use starknet::macros::selector;
-use tracing::{debug, error};
+use std::time::Duration;
+use tracing::{debug, error, info};
 
 /// `MetadataManager` is responsible for managing metadata information related to tokens.
 /// It works with the underlying storage and Starknet client to fetch and update token metadata.
@@ -27,10 +28,9 @@ pub struct MetadataImage {
 }
 
 #[derive(Copy, Clone)]
-pub enum CacheOption {
-    Cache,
-    NoCache,
-    Default,
+pub enum ImageCacheOption {
+    Save,
+    DoNotSave,
 }
 
 /// Represents possible errors that can arise while working with metadata in the manager.
@@ -71,7 +71,7 @@ impl<'a, T: Storage, C: StarknetClient, F: FileManager> MetadataManager<'a, T, C
         &mut self,
         contract_address: FieldElement,
         token_id: CairoU256,
-        cache: CacheOption,
+        cache: ImageCacheOption,
         ipfs_gateway_uri: &str,
     ) -> Result<(), MetadataError> {
         let token_uri = self
@@ -91,10 +91,7 @@ impl<'a, T: Storage, C: StarknetClient, F: FileManager> MetadataManager<'a, T, C
                 .map(|s| s.replace("ipfs://", &ipfs_url))
                 .unwrap_or_default();
 
-            let image_name = url.rsplit('/').next().unwrap_or_default();
-            let image_ext = image_name.rsplit('.').next().unwrap_or_default();
-
-            self.fetch_token_image(url.as_str(), image_ext, cache, contract_address, &token_id)
+            self.fetch_token_image(url.as_str(), cache, contract_address, &token_id)
                 .await
                 .map_err(|_| MetadataError::RequestImageError)?;
         }
@@ -121,7 +118,7 @@ impl<'a, T: Storage, C: StarknetClient, F: FileManager> MetadataManager<'a, T, C
     pub async fn refresh_collection_token_metadata(
         &mut self,
         contract_address: FieldElement,
-        cache: CacheOption,
+        cache: ImageCacheOption,
         ipfs_gateway_uri: &str,
     ) -> Result<(), MetadataError> {
         let token_ids = self
@@ -156,13 +153,14 @@ impl<'a, T: Storage, C: StarknetClient, F: FileManager> MetadataManager<'a, T, C
     pub async fn fetch_token_image(
         &mut self,
         url: &str,
-        file_ext: &str,
-        cache: CacheOption,
+        cache: ImageCacheOption,
         contract_address: FieldElement,
         token_id: &CairoU256,
     ) -> Result<MetadataImage> {
+        info!("Fetching image... {}", url);
+
         match cache {
-            CacheOption::NoCache => {
+            ImageCacheOption::DoNotSave => {
                 let response = self.request_client.head(url).send().await?;
                 let (content_type, content_length) =
                     extract_metadata_from_headers(response.headers())?;
@@ -173,16 +171,27 @@ impl<'a, T: Storage, C: StarknetClient, F: FileManager> MetadataManager<'a, T, C
                     is_cache_updated: false,
                 })
             }
-            _ => {
-                debug!("Fetching image... {}", url);
-                let response = reqwest::get(url).await?;
+            ImageCacheOption::Save => {
+                let response = self
+                    .request_client
+                    .get(url)
+                    .timeout(Duration::from_secs(5))
+                    .send()
+                    .await?;
+
                 let headers = response.headers().clone();
                 let bytes = response.bytes().await?;
                 let (content_type, content_length) = extract_metadata_from_headers(&headers)?;
+                let file_ext = file_extension_from_mime_type(content_type.as_str());
+
+                debug!(
+                    "Image: Content-Type={}, Content-Length={}, File-Ext={}",
+                    content_type, content_length, file_ext
+                );
 
                 self.file_manager
                     .save(&FileInfo {
-                        name: format!("{}.{}", token_id.to_hex(), file_ext),
+                        name: format!("{}.{}", token_id.to_decimal(false), file_ext),
                         content: bytes.to_vec(),
                         dir_path: Some(to_hex_str(&contract_address)),
                     })
@@ -368,7 +377,7 @@ mod tests {
         let result = metadata_manager
             .refresh_collection_token_metadata(
                 contract_address,
-                CacheOption::NoCache,
+                ImageCacheOption::DoNotSave,
                 ipfs_gateway_uri,
             )
             .await;

--- a/crates/ark-metadata/src/metadata_manager.rs
+++ b/crates/ark-metadata/src/metadata_manager.rs
@@ -101,6 +101,7 @@ impl<'a, T: Storage, C: StarknetClient, F: FileManager> MetadataManager<'a, T, C
 
         self.storage
             .register_token_metadata(&contract_address, token_id, token_metadata)
+            .await
             .map_err(|_e| MetadataError::DatabaseError)?;
 
         Ok(())
@@ -126,6 +127,7 @@ impl<'a, T: Storage, C: StarknetClient, F: FileManager> MetadataManager<'a, T, C
         let token_ids = self
             .storage
             .find_token_ids_without_metadata_in_collection(contract_address)
+            .await
             .map_err(|_| MetadataError::DatabaseError)?;
 
         for token_id in token_ids {

--- a/crates/ark-metadata/src/storage.rs
+++ b/crates/ark-metadata/src/storage.rs
@@ -1,26 +1,33 @@
 use crate::types::{StorageError, TokenMetadata};
+use anyhow::Result;
 use ark_starknet::CairoU256;
+use async_trait::async_trait;
 #[cfg(any(test, feature = "mock"))]
 use mockall::automock;
 use starknet::core::types::FieldElement;
 
 #[cfg_attr(any(test, feature = "mock"), automock)]
+#[async_trait]
 pub trait Storage {
-    fn register_token_metadata(
+    async fn register_token_metadata(
         &self,
         contract_address: &FieldElement,
         token_id: CairoU256,
         token_metadata: TokenMetadata,
     ) -> Result<(), StorageError>;
 
-    fn has_token_metadata(
+    async fn has_token_metadata(
         &self,
         contract_address: FieldElement,
         token_id: CairoU256,
     ) -> Result<bool, StorageError>;
 
-    fn find_token_ids_without_metadata_in_collection(
+    async fn find_token_ids_without_metadata_in_collection(
         &self,
         contract_address: FieldElement,
     ) -> Result<Vec<CairoU256>, StorageError>;
+
+    async fn find_token_ids_without_metadata(
+        &self,
+    ) -> Result<Vec<(FieldElement, CairoU256)>, StorageError>;
 }

--- a/crates/ark-metadata/src/types.rs
+++ b/crates/ark-metadata/src/types.rs
@@ -26,7 +26,7 @@ pub enum DisplayType {
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum AttributeValue {
+pub enum MetadataAttributeValue {
     String(String),
     Number(Number),
     Bool(bool),
@@ -39,7 +39,7 @@ pub enum AttributeValue {
 pub struct Attribute {
     pub display_type: Option<DisplayType>,
     pub trait_type: Option<String>,
-    pub value: AttributeValue,
+    pub value: MetadataAttributeValue,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/crates/ark-metadata/src/utils.rs
+++ b/crates/ark-metadata/src/utils.rs
@@ -42,6 +42,24 @@ async fn get_http_metadata(uri: &str, client: &Client) -> Result<TokenMetadata> 
     Ok(metadata)
 }
 
+pub fn file_extension_from_mime_type(mime_type: &str) -> &str {
+    match mime_type {
+        "image/png" => "png",
+        "image/jpeg" => "jpg",
+        "image/gif" => "gif",
+        "image/bmp" => "bmp",
+        "image/webp" => "webp",
+        "image/svg+xml" => "svg",
+        "video/mp4" => "mp4",
+        "video/quicktime" => "mov",
+        "video/x-msvideo" => "avi",
+        "video/x-matroska" => "mkv",
+        "video/ogg" => "ogv",
+        "video/webm" => "webm",
+        _ => "",
+    }
+}
+
 fn get_onchain_metadata(uri: &str) -> Result<TokenMetadata> {
     // Try to split from the comma as it is the standard with on chain metadata
     let url_encoded = urlencoding::decode(uri).map(|s| String::from(s.as_ref()));

--- a/crates/ark-starknet/Cargo.toml
+++ b/crates/ark-starknet/Cargo.toml
@@ -10,8 +10,8 @@ starknet.workspace = true
 url = "2.3.1"
 regex = "1.9.1"
 mockall = "0.11.2"
-num-bigint = { version = "0.4.3", default-features = false }
-num-traits = "0.2"
+num-bigint = "0.4.4"
+num-traits = "0.2.17"
 
 [features]
 mock = []


### PR DESCRIPTION
## Description

Add a missing function to the ark-metadata storage and rename the struct for Image Cache Options.

## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix (`fix:`)

## Added tests?

- [X] 🙅 no, because they aren't needed

## Added to documentation?

- [X] 🙅 no documentation needed