### PR TITLE
fix(ark-metadata): refresh token metadata

### DIFF
--- a/crates/ark-metadata/src/storage.rs
+++ b/crates/ark-metadata/src/storage.rs
@@ -22,12 +22,8 @@ pub trait Storage {
         token_id: CairoU256,
     ) -> Result<bool, StorageError>;
 
-    async fn find_token_ids_without_metadata_in_collection(
-        &self,
-        contract_address: FieldElement,
-    ) -> Result<Vec<CairoU256>, StorageError>;
-
     async fn find_token_ids_without_metadata(
         &self,
+        contract_address_filter: Option<FieldElement>,
     ) -> Result<Vec<(FieldElement, CairoU256)>, StorageError>;
 }


### PR DESCRIPTION
## Description

This pull request enhances the metadata_manager function definitions to enable the retrieval of tokens without metadata. Additionally, it introduces an optional filter for contract_address, allowing for more flexible token retrieval.
+
It fixes a bug related to `get_token_uri` function

## What type of PR is this? (check all applicable)

- [X] 🐛 Bug Fix (`fix:`)

## Added tests?

- [X] 🙅 no, because they aren't needed

## Added to documentation?

- [X] 🙅 no documentation needed
