### PR TITLE
feat(listing): add fulfill listing & tests

### DIFF
--- a/crates/ark-contracts/arkchain/src/order/order_v1.cairo
+++ b/crates/ark-contracts/arkchain/src/order/order_v1.cairo
@@ -8,6 +8,7 @@ use starknet::ContractAddress;
 use starknet::contract_address_to_felt252;
 use arkchain::order::types::{OrderTrait, OrderValidationError, OrderType, RouteType};
 use arkchain::crypto::hash::starknet_keccak;
+use arkchain::order::types::FulfillInfo;
 
 const ORDER_VERSION_V1: felt252 = 'v1';
 // Auction -> end_amount (reserve price) > start_amount (starting price).

--- a/crates/ark-contracts/arkchain/tests/common/signer.cairo
+++ b/crates/ark-contracts/arkchain/tests/common/signer.cairo
@@ -1,0 +1,14 @@
+use arkchain::crypto::signer::{Signer, SignInfo};
+use snforge_std::signature::{
+    StarkCurveKeyPair, StarkCurveKeyPairTrait, Signer as SNSigner, Verifier
+};
+
+fn sign_mock(message_hash: felt252) -> Signer {
+    let private_key: felt252 = 0x1234567890987654321;
+    let mut key_pair = StarkCurveKeyPairTrait::from_private_key(private_key);
+    let (r, s) = key_pair.sign(message_hash).unwrap();
+
+    Signer::WEIERSTRESS_STARKNET(
+        SignInfo { user_pubkey: key_pair.public_key, user_sig_r: r, user_sig_s: s, }
+    )
+}

--- a/crates/ark-contracts/arkchain/tests/integration/test_create_listing_order.cairo
+++ b/crates/ark-contracts/arkchain/tests/integration/test_create_listing_order.cairo
@@ -18,7 +18,7 @@ use super::super::common::setup::{setup, setup_listing_order_with_sign};
 #[should_panic(expected: ('OB: order already exists',))]
 fn test_create_existing_order() {
     let block_timestamp = 1699556828; // starknet::get_block_timestamp();
-    let (order_listing, signer, _order_hash, token_hash) = setup(block_timestamp);
+    let (order_listing, signer, _order_hash, token_hash) = setup(block_timestamp, false);
     let contract = declare('orderbook');
     let contract_data = array![0x00E4769a4d2F7F69C70951A003eBA5c32707Cef3CdfB6B27cA63567f51cdd078];
     let contract_address = contract.deploy(@contract_data).unwrap();
@@ -30,13 +30,13 @@ fn test_create_existing_order() {
 #[test]
 fn test_create_listing_order() {
     let block_timestamp = 1699556828; // starknet::get_block_timestamp();
-    let (order_listing, signer, _order_hash, token_hash) = setup(block_timestamp);
+    let (order_listing, signer, _order_hash, token_hash) = setup(block_timestamp, false);
     let contract = declare('orderbook');
     let contract_data = array![0x00E4769a4d2F7F69C70951A003eBA5c32707Cef3CdfB6B27cA63567f51cdd078];
     let contract_address = contract.deploy(@contract_data).unwrap();
     let dispatcher = OrderbookDispatcher { contract_address };
 
-    let order = dispatcher.create_order(order: order_listing, signer: signer);
+    dispatcher.create_order(order: order_listing, signer: signer);
     let order = dispatcher.get_order(_order_hash);
     let order_status = dispatcher.get_order_status(_order_hash);
     let order_type = dispatcher.get_order_type(_order_hash);

--- a/crates/ark-contracts/arkchain/tests/integration/test_fulfill_listing.cairo
+++ b/crates/ark-contracts/arkchain/tests/integration/test_fulfill_listing.cairo
@@ -1,0 +1,179 @@
+use arkchain::order::types::FulfillInfoTrait;
+use core::traits::TryInto;
+use core::traits::Into;
+use core::option::OptionTrait;
+use snforge_std::{PrintTrait, declare, ContractClassTrait};
+use arkchain::orderbook::Orderbook;
+use arkchain::orderbook::orderbook;
+use arkchain::order::order_v1::OrderV1;
+use arkchain::order::order_v1::RouteType;
+use arkchain::crypto::signer::{Signer, SignInfo};
+use arkchain::order::order_v1::OrderTrait;
+use arkchain::order::order_v1::OrderType;
+use arkchain::order::types::{OrderStatus, FulfillInfo};
+use arkchain::orderbook::{OrderbookDispatcher, OrderbookDispatcherTrait};
+use starknet::deploy_syscall;
+
+use super::super::common::signer::sign_mock;
+use super::super::common::setup::{setup, setup_listing_order_with_sign};
+
+// try to fulfill an order that doesn't exist
+#[should_panic(expected: ('OB: order not found',))]
+#[test]
+fn test_create_listing_order_and_fulfill_non_existing_order() {
+    let block_timestamp = 1699556828; // starknet::get_block_timestamp();
+    let (order_listing, signer, _order_hash, token_hash) = setup(block_timestamp, false);
+    let contract = declare('orderbook');
+    let contract_data = array![0x00E4769a4d2F7F69C70951A003eBA5c32707Cef3CdfB6B27cA63567f51cdd078];
+    let contract_address = contract.deploy(@contract_data).unwrap();
+    let dispatcher = OrderbookDispatcher { contract_address };
+
+    let fulfill_info = FulfillInfo {
+        order_hash: 0x00E4769a444F7FF9C70951A333eBA5c32707Cef3CdfB6B27cA63567f51cdd078
+            .try_into()
+            .unwrap(),
+        related_order_hash: Option::None,
+        fulfiller: 0x00E4769a4d2F7F69C70951A333eBA5c32707Cef3CdfB6B27cA63567f51cdd078
+            .try_into()
+            .unwrap(),
+        token_chain_id: 0x534e5f4d41494e.try_into().unwrap(),
+        token_address: 0x01435498bf393da86b4733b9264a86b58a42b31f8d8b8ba309593e5c17847672
+            .try_into()
+            .unwrap(),
+        token_id: Option::Some(8),
+    };
+
+    let fulfill_info_hash = fulfill_info.hash();
+    let signer = sign_mock(fulfill_info_hash);
+
+    dispatcher.fulfill_order(fulfill_info, signer);
+}
+
+// create and order & fulfill it
+#[test]
+fn test_create_listing_order_and_fulfill() {
+    let block_timestamp = 1699556828; // starknet::get_block_timestamp();
+    let (order_listing, signer, order_hash, token_hash) = setup(block_timestamp, false);
+    let contract = declare('orderbook');
+    let contract_data = array![0x00E4769a4d2F7F69C70951A003eBA5c32707Cef3CdfB6B27cA63567f51cdd078];
+    let contract_address = contract.deploy(@contract_data).unwrap();
+    let dispatcher = OrderbookDispatcher { contract_address };
+
+    dispatcher.create_order(order: order_listing, signer: signer);
+    let order = dispatcher.get_order(order_hash);
+
+    let fulfill_info = FulfillInfo {
+        order_hash: order_hash,
+        related_order_hash: Option::None,
+        fulfiller: 0x00E4769a4d2F7F69C70931A003eBA5c32707Cef3CdfB6B27cA63567f51cdd078
+            .try_into()
+            .unwrap(),
+        token_chain_id: 0x534e5f4d41494e.try_into().unwrap(),
+        token_address: 0x01435498bf393da86b4733b9264a86b58a42b31f8d8b8ba309593e5c17847672
+            .try_into()
+            .unwrap(),
+        token_id: Option::Some(10),
+    };
+
+    let fulfill_info_hash = fulfill_info.hash();
+    let signer = sign_mock(fulfill_info_hash);
+
+    dispatcher.fulfill_order(fulfill_info, signer);
+
+    let order: OrderV1 = dispatcher.get_order(order_hash);
+    let order_status = dispatcher.get_order_status(order_hash);
+
+    assert(order_status == OrderStatus::Fulfilled.into(), 'Status should be fulfilled');
+}
+
+// try to fulfill an order with the same fulfiller as the order creator
+#[should_panic(expected: ('OB: order has same offerer',))]
+#[test]
+fn test_create_listing_order_and_fulfill_with_same_fulfiller() {
+    let block_timestamp = 1699556828; // starknet::get_block_timestamp();
+    let (order_listing, signer, order_hash, token_hash) = setup(block_timestamp, false);
+    let contract = declare('orderbook');
+    let contract_data = array![0x00E4769a4d2F7F69C70951A003eBA5c32707Cef3CdfB6B27cA63567f51cdd078];
+    let contract_address = contract.deploy(@contract_data).unwrap();
+    let dispatcher = OrderbookDispatcher { contract_address };
+
+    dispatcher.create_order(order: order_listing, signer: signer);
+    let order = dispatcher.get_order(order_hash);
+
+    let fulfill_info = FulfillInfo {
+        order_hash: order_hash,
+        related_order_hash: Option::None,
+        fulfiller: 0x00E4769a4d2F7F69C70951A003eBA5c32707Cef3CdfB6B27cA63567f51cdd078
+            .try_into()
+            .unwrap(),
+        token_chain_id: 0x534e5f4d41494e.try_into().unwrap(),
+        token_address: 0x01435498bf393da86b4733b9264a86b58a42b31f8d8b8ba309593e5c17847672
+            .try_into()
+            .unwrap(),
+        token_id: Option::Some(10),
+    };
+
+    let fulfill_info_hash = fulfill_info.hash();
+    let signer = sign_mock(fulfill_info_hash);
+
+    dispatcher.fulfill_order(fulfill_info, signer);
+}
+
+#[should_panic(expected: ('OB: order not fulfillable',))]
+#[test]
+fn test_fulfill_already_fulfilled_order() {
+    let block_timestamp = 1699556828;
+    let (order_listing, signer, order_hash, token_hash) = setup(block_timestamp, false);
+    let contract = declare('orderbook');
+    let contract_data = array![0x00E4769a4d2F7F69C70951A003eBA5c32707Cef3CdfB6B27cA63567f51cdd078];
+    let contract_address = contract.deploy(@contract_data).unwrap();
+    let dispatcher = OrderbookDispatcher { contract_address };
+    dispatcher.create_order(order: order_listing, signer: signer);
+
+    let fulfill_info = FulfillInfo {
+        order_hash: order_hash,
+        related_order_hash: Option::None,
+        fulfiller: 0x00E4769a4d2F7F69C70931A003eBA5c32707Cef3CdfB6B27cA63567f51cdd078
+            .try_into()
+            .unwrap(),
+        token_chain_id: 0x534e5f4d41494e.try_into().unwrap(),
+        token_address: 0x01435498bf393da86b4733b9264a86b58a42b31f8d8b8ba309593e5c17847672
+            .try_into()
+            .unwrap(),
+        token_id: Option::Some(10),
+    };
+    let fulfill_info_hash = fulfill_info.hash();
+    let signer = sign_mock(fulfill_info_hash);
+    dispatcher.fulfill_order(fulfill_info, signer);
+    dispatcher.fulfill_order(fulfill_info, signer);
+}
+
+#[should_panic(expected: ('OB: order expired',))]
+#[test]
+fn test_fulfill_expired_order() {
+    let block_timestamp = starknet::get_block_timestamp();
+    let (mut order_listing, signer, order_hash, token_hash) = setup(block_timestamp, true);
+    let contract = declare('orderbook');
+    let contract_data = array![0x00E4769a4d2F7F69C70951A003eBA5c32707Cef3CdfB6B27cA63567f51cdd078];
+    let contract_address = contract.deploy(@contract_data).unwrap();
+    let dispatcher = OrderbookDispatcher { contract_address };
+    order_listing.end_date = starknet::get_block_timestamp();
+
+    dispatcher.create_order(order: order_listing, signer: signer);
+
+    let fulfill_info = FulfillInfo {
+        order_hash: order_hash,
+        related_order_hash: Option::None,
+        fulfiller: 0x00E4269a4d2F7F69C70951A003eBA5c32707Cef3CdfB6B27cA63567f51cdd078
+            .try_into()
+            .unwrap(),
+        token_chain_id: 0x534e5f4d41494e.try_into().unwrap(),
+        token_address: 0x01435498bf393da86b4733b9264a86b58a42b31f8d8b8ba309593e5c17847672
+            .try_into()
+            .unwrap(),
+        token_id: Option::Some(10),
+    };
+    let fulfill_info_hash = fulfill_info.hash();
+    let fulfill_signer = sign_mock(fulfill_info_hash);
+    dispatcher.fulfill_order(fulfill_info, fulfill_signer);
+}

--- a/crates/ark-contracts/arkchain/tests/lib.cairo
+++ b/crates/ark-contracts/arkchain/tests/lib.cairo
@@ -1,10 +1,12 @@
 mod common {
     mod setup;
+    mod signer;
 }
 
 mod integration {
     mod test_create_listing_order;
     mod test_create_auction_offers;
+    mod test_fulfill_listing;
 }
 
 mod unit {

--- a/scripts/signature/src/index.ts
+++ b/scripts/signature/src/index.ts
@@ -1,6 +1,6 @@
 import { ec, encode } from "starknet";
-import { OrderV1, RouteType } from "./types";
-import { hashOrder } from "./utils";
+import { OrderV1, RouteType, ExecutionInfo } from "./types";
+import { hashOrder, hashExecutionInfo } from "./utils";
 
 function main() {
   const privateKey = "0x1234567890987654321";
@@ -40,4 +40,35 @@ function main() {
   console.log("Signature S:", signature.s.toString());
 }
 
+function execution() {
+  const privateKey = "0x1234567890987654321";
+  const starknetPublicKey = ec.starkCurve.getStarkKey(privateKey);
+  const fullPublicKey = encode.addHexPrefix(
+    encode.buf2hex(ec.starkCurve.getPublicKey(privateKey, false))
+  );
+
+  const executionInfo: ExecutionInfo = {
+    orderHash:
+      "0x00E4769a444F7FF9C70951A333eBA5c32707Cef3CdfB6B27cA63567f51cdd078",
+    fulfiller:
+      "0x00E4769a4d2F7F69C70951A333eBA5c32707Cef3CdfB6B27cA63567f51cdd078",
+    tokenChainId: "0x534e5f4d41494e",
+    tokenAddress:
+      "0x01435498bf393da86b4733b9264a86b58a42b31f8d8b8ba309593e5c17847672",
+    tokenId: { high: 0, low: 10 },
+  };
+
+  const executionInfoMessageHash = hashExecutionInfo(executionInfo);
+  const signature = ec.starkCurve.sign(executionInfoMessageHash, privateKey);
+
+  console.log("Order Message Hash:", executionInfoMessageHash);
+  console.log("StarkNet Public Key:", starknetPublicKey);
+  console.log("Full Public Key:", fullPublicKey);
+  console.log("Signature R:", signature.r.toString());
+  console.log("Signature S:", signature.s.toString());
+}
+
+console.log("------ ORDER -------");
 main();
+console.log("------ Execution ------");
+execution();

--- a/scripts/signature/src/types.ts
+++ b/scripts/signature/src/types.ts
@@ -18,6 +18,15 @@ export type OrderV1 = {
   additionalData: BigNumberish[];
 };
 
+export type ExecutionInfo = {
+  orderHash: BigNumberish;
+  fulfiller: BigNumberish;
+  offerHash?: BigNumberish;
+  tokenChainId: BigNumberish;
+  tokenAddress: BigNumberish;
+  tokenId?: Uint256;
+};
+
 export enum RouteType {
   Erc20ToErc721 = 0,
   Erc721ToErc20 = 1,

--- a/scripts/signature/src/utils.ts
+++ b/scripts/signature/src/utils.ts
@@ -1,5 +1,5 @@
 import { num, BigNumberish } from "starknet";
-import { OrderV1 } from "./types";
+import { OrderV1, ExecutionInfo } from "./types";
 import * as starknet from "@scure/starknet";
 
 // Helper function to convert BigNumberish to Uint8Array
@@ -49,6 +49,37 @@ export function hashOrder(order: OrderV1): string {
     const additionalDataArray = bigNumberishToUint8Array(item);
     results = new Uint8Array([...results, ...additionalDataArray]);
   });
+
+  // Generate the hash from the concatenated Uint8Arrays.
+  const generatedHash = starknet.keccak(results);
+
+  // Convert the generated hash to a hexadecimal string.
+  return num.toHex(generatedHash);
+}
+
+/**
+ * Constructs a Keccak hash from the order's properties.
+ * Property order is important as it determines the hash output.
+ * @param {OrderV1} order - The order to hash.
+ * @returns {string} The Keccak hash of the order as a hex string.
+ */
+export function hashExecutionInfo(execution: ExecutionInfo): string {
+  // Convert order properties to Uint8Array and concatenate them.
+  // The array is initialized with a fixed set of properties.
+  let results = Uint8Array.from([
+    ...bigNumberishToUint8Array(execution.orderHash),
+    ...bigNumberishToUint8Array(execution.fulfiller),
+    ...bigNumberishToUint8Array(execution.offerHash || 1),
+    ...bigNumberishToUint8Array(execution.tokenChainId),
+    ...bigNumberishToUint8Array(execution.tokenAddress),
+    ...(execution.tokenId
+      ? [
+          ...bigNumberishToUint8Array(0),
+          ...bigNumberishToUint8Array(execution.tokenId.low),
+          ...bigNumberishToUint8Array(execution.tokenId.high),
+        ]
+      : [...bigNumberishToUint8Array(1)]),
+  ]);
 
   // Generate the hash from the concatenated Uint8Arrays.
   const generatedHash = starknet.keccak(results);


### PR DESCRIPTION
## Description

This pull request introduces significant updates to the `Orderbook` contract, focusing on the implementation of listing order fulfillment and the enhancement of testing scenarios.

#### Key Additions:

1. **Fulfilling Listing Order Functionality:**
   - A new function, `fulfill_order`, has been added to handle the process of fulfilling orders. This function takes in `execution_info` and `signer` as parameters and follows these steps:
     - Verifies the signer.
     - Validates the existence of the order and its status.
     - Checks if the order is open and not fulfilled by the same offerer.
     - Distinguishes the order type and proceeds with the fulfillment process for listing orders.

2. **Private Function for Listing Order Fulfillment:**
   - The `_fulfill_listing_order` private function has been implemented to specifically handle listing orders. It checks the order's expiration date and updates the order status to 'Fulfilled' upon successful execution.

3. **Enhanced Test Coverage:**
   - New test scenarios have been added to validate the functionality:
     - `test_create_listing_order_and_fulfill_non_existing_order`: Ensures the system correctly handles attempts to fulfill non-existing orders.
     - `test_create_listing_order_and_fulfill`: Tests the successful creation and fulfillment of a listing order.
     - `test_create_listing_order_and_fulfill_with_same_fulfiller`: Validates that an order cannot be fulfilled by the same entity that created it.

These updates aim to streamline the order fulfillment process, particularly for listing orders, while ensuring robustness through comprehensive testing.

<!-- 
Please do not leave this blank.
Describe the changes in this PR. What does it [add/remove/fix/replace]? 

For crafting a good description, consider using ChatGPT to help articulate your changes.
-->

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature (`feat:`)
- [ ] 🐛 Bug Fix (`fix:`)
- [ ] 📝 Documentation Update (`docs:`)
- [ ] 🎨 Style (`style:`)
- [ ] 🧑‍💻 Code Refactor (`refactor:`)
- [ ] 🔥 Performance Improvements (`perf:`)
- [ ] ✅ Test (`test:`)
- [ ] 🤖 Build (`build:`)
- [ ] 🔁 CI (`ci:`)
- [ ] 📦 Chore (`chore:`)
- [ ] ⏩ Revert (`revert:`)
- [ ] 🚀 Breaking Changes (`BREAKING CHANGE:`)

## Related Tickets & Documents

<!-- 
Please use this format to link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 Documentation
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

<!-- Describe any additional tasks, if any, and provide steps. -->

## [optional] What gif best describes this PR or how it makes you feel?

<!-- Share a fun gif related to your PR! -->

### PR Title and Description Guidelines:

- Ensure your PR title follows semantic versioning standards. This helps automate releases and changelogs.
- Use types like `feat:`, `fix:`, `chore:`, `BREAKING CHANGE:` etc. in your PR title.
- Your PR title will be used as a commit message when merging. Make sure it adheres to [Conventional Commits standards](https://www.conventionalcommits.org/).

## Closing Issues

<!-- 
Use keywords to close related issues. This ensures that the associated issues will automatically close when the PR is merged.

- `Fixes #123` will close issue 123 when the PR is merged.
- `Closes #123` will also close issue 123 when the PR is merged.
- `Resolves #123` will also close issue 123 when the PR is merged.

You can also use multiple keywords in one comment:
- `Fixes #123, Resolves #456`

More info: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
