### PR TITLE
fix(ark-metadata): handle non-standard metadata

### DIFF
--- a/crates/ark-metadata/src/types.rs
+++ b/crates/ark-metadata/src/types.rs
@@ -1,5 +1,6 @@
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Number;
+use std::str::FromStr;
 use std::{collections::HashMap, fmt};
 
 #[derive(Debug, PartialEq)]
@@ -37,6 +38,20 @@ pub enum DisplayType {
     BoostNumber,
     #[serde(rename = "date")]
     Date,
+}
+
+impl FromStr for DisplayType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "number" => Ok(DisplayType::Number),
+            "boost_percentage" => Ok(DisplayType::BoostPercentage),
+            "boost_number" => Ok(DisplayType::BoostNumber),
+            "date" => Ok(DisplayType::Date),
+            _ => Err(()), // Gérer le cas d'erreur si la chaîne ne correspond à aucun type
+        }
+    }
 }
 
 impl fmt::Display for DisplayType {

--- a/crates/ark-metadata/src/types.rs
+++ b/crates/ark-metadata/src/types.rs
@@ -49,7 +49,7 @@ impl FromStr for DisplayType {
             "boost_percentage" => Ok(DisplayType::BoostPercentage),
             "boost_number" => Ok(DisplayType::BoostNumber),
             "date" => Ok(DisplayType::Date),
-            _ => Err(()), // Gérer le cas d'erreur si la chaîne ne correspond à aucun type
+            _ => Err(()),
         }
     }
 }

--- a/crates/ark-metadata/src/utils.rs
+++ b/crates/ark-metadata/src/utils.rs
@@ -223,7 +223,6 @@ fn fetch_onchain_metadata(uri: &str) -> Result<TokenMetadata> {
             attributes
                 .iter()
                 .filter_map(|attr| {
-                    // Cas standard où les attributs ont "trait_type" et "value"
                     if let (Some(trait_type), Some(value)) = (
                         attr.get("trait_type")
                             .or_else(|| attr.get("trait"))

--- a/crates/ark-metadata/src/utils.rs
+++ b/crates/ark-metadata/src/utils.rs
@@ -244,7 +244,7 @@ fn fetch_onchain_metadata(uri: &str) -> Result<TokenMetadata> {
                         Some(MetadataAttribute {
                             display_type: display_type,
                             trait_type: Some(trait_type),
-                            value: value,
+                            value,
                         })
                     } else if let (Some(trait_type), Some(value)) = (
                         attr.get("trait").and_then(|v| v.as_str()).map(String::from),
@@ -254,7 +254,7 @@ fn fetch_onchain_metadata(uri: &str) -> Result<TokenMetadata> {
                         Some(MetadataAttribute {
                             display_type: None,
                             trait_type: Some(trait_type),
-                            value: value,
+                            value,
                         })
                     } else {
                         None


### PR DESCRIPTION
## Description

This pull request adds support for handling non-standard metadata structures in our application. Previously, the code assumed that all metadata followed a standard format with specific fields such as trait_type and value. However, some metadata structures differ, using fields like trait instead of trait_type.